### PR TITLE
Add a build_time attribute to /about

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY Gemfile .
 COPY Gemfile.lock .
 RUN bundle install
 RUN echo $omejdn_version > .version
+RUN date +"%Y-%m-%d %T" >> .version
 
 COPY . .
 

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -23,9 +23,9 @@ require 'bcrypt'
 OMEJDN_LICENSE = 'Apache2.0'
 
 def version
-  return File.read('.version').chomp if File.file? '.version'
+  return File.readlines('.version').map(&:chomp) if File.file? '.version'
 
-  'unknown'
+  ['unknown','unknown']
 end
 
 def debug
@@ -714,6 +714,7 @@ end
 
 get '/about' do
   headers['Content-Type'] = 'application/json'
-  return JSON.generate({ 'version' => version,
-                         'license' => OMEJDN_LICENSE })
+  return JSON.generate({ 'version' => version[0],
+                         'license' => OMEJDN_LICENSE,
+                         'build_time' => version[1]})
 end


### PR DESCRIPTION
This may be quite useful to know when a server was last updated,
and may help with diagnosing problems.