### PR TITLE
Added a config value `accept_audience`

### DIFF
--- a/config/omejdn.yml
+++ b/config/omejdn.yml
@@ -14,6 +14,9 @@ app_env: debug
 # Enable OpenID funtionality
 openid: true
 
+# Overwrite the aud claim value to accept in client's bearer tokens (defaults to host)
+#accept_audience:
+
 # Token singing keys and default values
 token:
   expiration: 3600

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -69,7 +69,7 @@ class Client
 
       puts "Client #{jwt_cid} found"
       # Try verify
-      aud = ENV['OMEJDN_JWT_AUD_OVERRIDE'] || Config.base_config['host']
+      aud = Config.base_config['accept_audience']
       JWT.decode jwt, client.certificate&.public_key, true,
                  { nbf_leeway: 30, aud: aud, verify_aud: true, algorithm: jwt_alg }
       return client

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -46,6 +46,8 @@ def adjust_config
   base_config['bind_to'] = ENV['BIND_TO'] || base_config['bind_to'] || '0.0.0.0'
   base_config['allow_origin'] = ENV['ALLOW_ORIGIN'] || base_config['allow_origin'] || '*'
   base_config['app_env'] = ENV['APP_ENV'] || base_config['app_env'] || 'debug'
+  base_config['accept_audience'] =
+    ENV['OMEJDN_JWT_AUD_OVERRIDE'] || base_config['accept_audience'] || base_config['host']
   Config.base_config = base_config
 end
 


### PR DESCRIPTION
Intended to use in cases where the audience param shall not be the host URL.
Can be overwritten as before by the ENV variable `OMEJDN_JWT_AUD_OVERRIDE`