### PR TITLE
Verbose output for the Psych YAML Parser

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 require 'yaml'
-
-OMEJDN_BASE_CONFIG_FILE = 'config/omejdn.yml'
-OMEJDN_USER_CONFIG_FILE = 'config/users.yml'
-OMEJDN_CLIENT_CONFIG_FILE = 'config/clients.yml'
-OMEJDN_USER_BACKEND_CONFIG = 'config/user_backend.yml'
-OMEJDN_OAUTH_PROVIDER_CONFIG = 'config/oauth_providers.yml'
-SCOPE_DESCRIPTION_CONFIG = 'config/scope_description.yml'
-SCOPE_MAPPING_CONFIG = 'config/scope_mapping.yml'
-WEBFINGER_CONFIG = 'config/webfinger.yml'
+OMEJDN_CONFIG_DIR            = 'config'
+OMEJDN_BASE_CONFIG_FILE      = "#{OMEJDN_CONFIG_DIR}/omejdn.yml"
+OMEJDN_USER_CONFIG_FILE      = "#{OMEJDN_CONFIG_DIR}/users.yml"
+OMEJDN_CLIENT_CONFIG_FILE    = "#{OMEJDN_CONFIG_DIR}/clients.yml"
+OMEJDN_USER_BACKEND_CONFIG   = "#{OMEJDN_CONFIG_DIR}/user_backend.yml"
+OMEJDN_OAUTH_PROVIDER_CONFIG = "#{OMEJDN_CONFIG_DIR}/oauth_providers.yml"
+SCOPE_DESCRIPTION_CONFIG     = "#{OMEJDN_CONFIG_DIR}/scope_description.yml"
+SCOPE_MAPPING_CONFIG         = "#{OMEJDN_CONFIG_DIR}/scope_mapping.yml"
+WEBFINGER_CONFIG             = "#{OMEJDN_CONFIG_DIR}/webfinger.yml"
 
 # Configuration helpers functions
 class Config
@@ -19,8 +19,12 @@ class Config
     file.close
   end
 
+  def self.read_config(file, fallback)
+    YAML.safe_load (File.read file), fallback: fallback, filename: file
+  end
+
   def self.client_config
-    YAML.safe_load File.read OMEJDN_CLIENT_CONFIG_FILE, fallback: []
+    read_config OMEJDN_CLIENT_CONFIG_FILE, []
   end
 
   def self.client_config=(clients)
@@ -29,7 +33,7 @@ class Config
   end
 
   def self.base_config
-    YAML.safe_load File.read OMEJDN_BASE_CONFIG_FILE
+    read_config OMEJDN_BASE_CONFIG_FILE, {}
   end
 
   def self.base_config=(config)
@@ -43,7 +47,7 @@ class Config
   end
 
   def self.user_backend_config
-    YAML.safe_load File.read OMEJDN_USER_BACKEND_CONFIG, fallback: {}
+    read_config OMEJDN_USER_BACKEND_CONFIG, {}
   end
 
   def self.user_backend_config=(config)
@@ -51,7 +55,7 @@ class Config
   end
 
   def self.oauth_provider_config
-    YAML.safe_load File.read OMEJDN_OAUTH_PROVIDER_CONFIG, fallback: []
+    read_config OMEJDN_OAUTH_PROVIDER_CONFIG, []
   end
 
   def self.oauth_provider_config=(providers)
@@ -59,15 +63,15 @@ class Config
   end
 
   def self.scope_description_config
-    YAML.safe_load File.read SCOPE_DESCRIPTION_CONFIG, fallback: {}
+    read_config SCOPE_DESCRIPTION_CONFIG, {}
   end
 
   def self.scope_mapping_config
-    YAML.safe_load File.read SCOPE_MAPPING_CONFIG, fallback: {}
+    read_config SCOPE_MAPPING_CONFIG, {}
   end
 
   def self.webfinger_config
-    YAML.safe_load File.read WEBFINGER_CONFIG, fallback: {}
+    read_config WEBFINGER_CONFIG, {}
   end
 
   def self.webfinger_config=(config)


### PR DESCRIPTION
This PR utilizes the `:filename` parameter for parsing YAML, resulting in more useful Syntax Error messages.

This may help with e.g. https://github.com/International-Data-Spaces-Association/omejdn-daps/issues/11