### PR TITLE
Dynamic reauthentication

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -38,10 +38,8 @@ class Config
 
   def self.base_config=(config)
     # Make sure those are integers
-    config['token']['expiration'] = config['token']['expiration'].to_i
-    if config['id_token'] && config['id_token']['expiration']
-      config['id_token']['expiration'] =
-        config['id_token']['expiration'].to_i
+    %w[token id_token].map { |t| config[t] }.compact.each do |c|
+      c['expiration'] = c['expiration'].to_i
     end
     write_config OMEJDN_BASE_CONFIG_FILE, config.to_yaml
   end

--- a/lib/db_plugins/user_db_plugin_ldap.rb
+++ b/lib/db_plugins/user_db_plugin_ldap.rb
@@ -68,7 +68,7 @@ class LdapUserDb < UserDb
   def ldap_entry_to_user(entry)
     user_backend_config = Config.user_backend_config
     user = User.new
-    user.username = entry[user_backend_config['ldap']['uidKey']][0]
+    user.username = entry.dig(user_backend_config.dig('ldap', 'uidKey'), 0)
     user.extern = true
     user.password = nil
     user.backend = 'ldap'
@@ -83,9 +83,9 @@ class LdapUserDb < UserDb
   def load_users
     user_backend_config = Config.user_backend_config
     ldap = Net::LDAP.new
-    ldap.host = user_backend_config['ldap']['host']
-    ldap.port = user_backend_config['ldap']['port']
-    base_dn = user_backend_config['ldap']['baseDN']
+    ldap.host = user_backend_config.dig('ldap', 'host')
+    ldap.port = user_backend_config.dig('ldap', 'port')
+    base_dn = user_backend_config.dig('ldap', 'baseDN')
     t_users = []
     ldap.search(base: base_dn) do |entry|
       puts "DN: #{entry.dn}"
@@ -110,12 +110,12 @@ class LdapUserDb < UserDb
 
   def bind(config, bdn, password)
     ldap = Net::LDAP.new
-    ldap.host = config['ldap']['host']
-    ldap.port = config['ldap']['port']
+    ldap.host = config.dig('ldap', 'host')
+    ldap.port = config.dig('ldap', 'port')
     puts "Trying bind for #{bdn}"
     ldap = Net::LDAP.new({
-                           host: config['ldap']['host'],
-                           port: config['ldap']['port'],
+                           host: config.dig('ldap', 'host'),
+                           port: config.dig('ldap', 'port'),
                            auth: {
                              method: :simple,
                              username: bdn,
@@ -133,9 +133,9 @@ class LdapUserDb < UserDb
 
   def nobind(config)
     Net::LDAP.new({
-                    host: config['ldap']['host'],
-                    port: config['ldap']['port'],
-                    base: config['ldap']['base_dn'],
+                    host: config.dig('ldap', 'host'),
+                    port: config.dig('ldap', 'port'),
+                    base: config.dig('ldap', 'baseDN'),
                     verbose: true,
                     encryption: {
                       method: :simple_tls,
@@ -147,8 +147,8 @@ class LdapUserDb < UserDb
   def lookup_user(user, config)
     return @dn_cache[user.username] unless @dnCache[user.username].nil?
 
-    connect(config).search(base: config['ldap']['baseDN'],
-                           filter: Net::LDAP::Filter.eq(config['ldap']['uidKey'],
+    connect(config).search(base: config.dig('ldap', 'baseDN'),
+                           filter: Net::LDAP::Filter.eq(config.dig('ldap', 'uidKey'),
                                                         user.username)) do |entry|
       return entry.dn
     end
@@ -164,8 +164,8 @@ class LdapUserDb < UserDb
 
     puts "Trying bind for #{user_dn}"
     Net::LDAP.new({
-                    host: user_backend_config['ldap']['host'],
-                    port: user_backend_config['ldap']['port'],
+                    host: user_backend_config.dig('ldap', 'host'),
+                    port: user_backend_config.dig('ldap', 'port'),
                     auth: {
                       method: :simple,
                       username: user_dn,
@@ -190,8 +190,8 @@ class LdapUserDb < UserDb
     user_backend_config = Config.user_backend_config
     ldap = connect(user_backend_config)
     p ldap
-    base_dn = user_backend_config['ldap']['baseDN']
-    uid_key = user_backend_config['ldap']['uidKey']
+    base_dn = user_backend_config.dig('ldap', 'baseDN')
+    uid_key = user_backend_config.dig('ldap', 'uidKey')
     puts "Looking for #{uid_key}=#{username}"
     filter = Net::LDAP::Filter.eq(uid_key, username)
     ldap.search(verbose: true, base: base_dn, filter: filter) do |entry|

--- a/lib/db_plugins/user_db_plugin_sqlite.rb
+++ b/lib/db_plugins/user_db_plugin_sqlite.rb
@@ -6,7 +6,7 @@ require 'sqlite3'
 class SqliteUserDb < UserDb
   def create_user(user)
     user_backend_config = Config.user_backend_config
-    db = SQLite3::Database.open user_backend_config['sqlite']['location']
+    db = SQLite3::Database.open user_backend_config.dig('sqlite', 'location')
     db.execute 'CREATE TABLE IF NOT EXISTS password(username TEXT PRIMARY KEY, password TEXT)'
     db.execute 'CREATE TABLE IF NOT EXISTS attributes(username TEXT, key TEXT, value TEXT, PRIMARY KEY (username, key))'
     db.execute 'INSERT INTO password(username, password) VALUES(?, ?)', user.username, user.password
@@ -19,8 +19,8 @@ class SqliteUserDb < UserDb
 
   def delete_user(username)
     user_backend_config = Config.user_backend_config
-    db = SQLite3::Database.open user_backend_config['sqlite']['location']
-    user_in_sqlite = (db.execute 'SELECT EXISTS(SELECT 1 FROM password WHERE username=?)', username)[0][0]
+    db = SQLite3::Database.open user_backend_config.dig('sqlite', 'location')
+    user_in_sqlite = (db.execute 'SELECT EXISTS(SELECT 1 FROM password WHERE username=?)', username).dig(0, 0)
     return false unless user_in_sqlite == 1
 
     db.execute 'DELETE FROM password WHERE username=?', username
@@ -43,8 +43,8 @@ class SqliteUserDb < UserDb
 
   def update_user(user)
     user_backend_config = Config.user_backend_config
-    db = SQLite3::Database.open user_backend_config['sqlite']['location']
-    user_in_sqlite = (db.execute 'SELECT EXISTS(SELECT 1 FROM password WHERE username=?)', user.username)[0][0]
+    db = SQLite3::Database.open user_backend_config.dig('sqlite', 'location')
+    user_in_sqlite = (db.execute 'SELECT EXISTS(SELECT 1 FROM password WHERE username=?)', user.username).dig(0, 0)
     return false unless user_in_sqlite == 1
 
     db.results_as_hash = true
@@ -63,7 +63,7 @@ class SqliteUserDb < UserDb
 
   def load_users
     user_backend_config = Config.user_backend_config
-    db = SQLite3::Database.open user_backend_config['sqlite']['location']
+    db = SQLite3::Database.open user_backend_config.dig('sqlite', 'location')
     db.results_as_hash = true
     begin
       t_users = db.execute 'SELECT * FROM password'
@@ -94,8 +94,8 @@ class SqliteUserDb < UserDb
 
   def change_password(user, password)
     user_backend_config = Config.user_backend_config
-    db = SQLite3::Database.open user_backend_config['sqlite']['location']
-    user_in_sqlite = (db.execute 'SELECT EXISTS(SELECT 1 FROM password WHERE username=?)', user.username)[0][0]
+    db = SQLite3::Database.open user_backend_config.dig('sqlite', 'location')
+    user_in_sqlite = (db.execute 'SELECT EXISTS(SELECT 1 FROM password WHERE username=?)', user.username).dig(0, 0)
     return false unless user_in_sqlite == 1
 
     db.execute 'UPDATE password SET password=? WHERE username=?', password, user.username

--- a/lib/db_plugins/user_db_plugin_yaml.rb
+++ b/lib/db_plugins/user_db_plugin_yaml.rb
@@ -39,7 +39,7 @@ class YamlUserDb < UserDb
 
   def load_users
     user_backend_config = Config.user_backend_config
-    (YAML.safe_load File.read user_backend_config['yaml']['location']) || []
+    (YAML.safe_load File.read user_backend_config.dig('yaml', 'location')) || []
   end
 
   def write_user_db(users)
@@ -48,7 +48,7 @@ class YamlUserDb < UserDb
       users_yaml << user.to_dict
     end
     user_backend_config = Config.user_backend_config
-    Config.write_config(user_backend_config['yaml']['location'], users_yaml.to_yaml)
+    Config.write_config(user_backend_config.dig('yaml', 'location'), users_yaml.to_yaml)
   end
 
   def users

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -120,6 +120,22 @@ class OAuthHelper
     metadata
   end
 
+  def self.adapt_requested_claims(req_claims)
+    # https://tools.ietf.org/id/draft-spencer-oauth-claims-00.html#rfc.section.3
+    known_sinks = %w[access_token id_token userinfo]
+    default_sinks = ['access_token']
+    known_sinks.each do |sink|
+      req_claims[sink] ||= {}
+      req_claims[sink].merge!(req_claims['*'] || {})
+    end
+    default_sinks.each do |sink|
+      req_claims[sink].merge!(req_claims['?'] || {})
+    end
+    req_claims.delete('*')
+    req_claims.delete('?')
+    req_claims
+  end
+
   def self.verify_authorization_request(params)
     client = Client.find_by_id params['client_id']
     unless params[:response_type] == 'code'

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -24,7 +24,7 @@ class OAuthHelper
     response = {}
     response['access_token'] = access_token
     response['id_token'] = id_token unless id_token.nil?
-    response['expires_in'] = Config.base_config['token']['expiration']
+    response['expires_in'] = Config.base_config.dig('token', 'expiration')
     response['token_type'] = 'bearer'
     response['scope'] = scopes.join ' '
     JSON.generate response
@@ -106,7 +106,7 @@ class OAuthHelper
   def self.openid_configuration(host, path)
     base_config = Config.base_config
     metadata = {}
-    metadata['issuer'] = base_config['token']['issuer']
+    metadata['issuer'] = base_config.dig('token', 'issuer')
     metadata['authorization_endpoint'] = "#{path}/authorize"
     metadata['token_endpoint'] = "#{path}/token"
     metadata['userinfo_endpoint'] = "#{path}/userinfo"
@@ -116,7 +116,7 @@ class OAuthHelper
     metadata['response_types_supported'] = ['code']
     metadata['response_modes_supported'] = ['query'] # FIXME: we only do query atm no fragment
     metadata['grant_types_supported'] = ['authorization_code']
-    metadata['id_token_signing_alg_values_supported'] = base_config['token']['algorithm']
+    metadata['id_token_signing_alg_values_supported'] = base_config.dig('token', 'algorithm')
     metadata
   end
 

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -30,16 +30,10 @@ class OAuthHelper
     JSON.generate response
   end
 
-  def self.userinfo(user, token)
-    userinfo = {}
+  def self.userinfo(client, user, token)
+    req_claims = token.dig('omejdn_reserved', 'userinfo_req_claims')
+    userinfo = TokenHelper.map_claims_to_userinfo(user.attributes, req_claims, client, token['scope'].split)
     userinfo['sub'] = user.username
-    user.attributes.each do |attribute|
-      token[0].each do |key, _|
-        next unless attribute['key'] == key
-
-        TokenHelper.add_jwt_claim(userinfo, key, attribute['value'])
-      end
-    end
     userinfo
   end
 

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -43,6 +43,7 @@ class OAuthHelper
 
   def self.error_response(error, desc = '')
     response = { 'error' => error, 'error_description' => desc }
+    p response
     JSON.generate response
   end
 

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -55,10 +55,10 @@ class Server
   end
 
   def self.load_skey(token_type = 'token')
-    filename = Config.base_config[token_type]['signing_key']
+    filename = Config.base_config.dig(token_type, 'signing_key')
     setup_skey(filename) unless File.exist? filename
     sk = OpenSSL::PKey::RSA.new File.read(filename)
-    pk = load_pkey(token_type).select { |c| c.dig('certs', 0) && (c['certs'][0].check_private_key sk) }.first
+    pk = load_pkey(token_type).select { |c| c.dig('certs', 0) && (c.dig('certs', 0).check_private_key sk) }.first
     (pk || {}).merge({ 'sk' => sk, 'pk' => sk.public_key })
   end
 end

--- a/lib/token_helper.rb
+++ b/lib/token_helper.rb
@@ -98,7 +98,8 @@ class TokenHelper
       'sub' => user.username,
       'nbf' => now,
       'iat' => now,
-      'exp' => now + base_config.dig('id_token', 'expiration')
+      'exp' => now + base_config.dig('id_token', 'expiration'),
+      'auth_time' => user.auth_time
     }.merge(map_claims_to_userinfo(user.attributes, claims, client, scopes))
     new_payload['nonce'] = nonce unless nonce.nil?
     signing_material = Server.load_skey('id_token')

--- a/lib/token_helper.rb
+++ b/lib/token_helper.rb
@@ -15,7 +15,6 @@ end
 
 # A helper for building JWT access tokens and ID tokens
 class TokenHelper
-  def server_key; end
 
   def self.build_access_token_stub(attrs, client, scopes, resources, claims)
     base_config = Config.base_config
@@ -106,14 +105,4 @@ class TokenHelper
     kid = JSON::JWK.new(signing_material['pk'])[:kid]
     JWT.encode new_payload, signing_material['sk'], 'RS256', { typ: 'JWT', kid: kid }
   end
-
-  # TODO: old, might needs to be changed
-  def self.subject_from_cert(cert)
-    Encoding.default_external = Encoding::UTF_8
-
-    subject = cert.subject.to_s(OpenSSL::X509::Name::ONELINE & ~ASN1_STRFLGS_ESC_MSB).delete(' ')
-    subject.force_encoding(Encoding::UTF_8)
-  end
-
-  private :server_key
 end

--- a/lib/token_helper.rb
+++ b/lib/token_helper.rb
@@ -89,17 +89,17 @@ class TokenHelper
   end
 
   # Builds a JWT ID token for client including user attributes
-  def self.build_id_token(client, uentry, nonce, claims, scopes)
+  def self.build_id_token(client, user, nonce, claims, scopes)
     base_config = Config.base_config
     now = Time.new.to_i
     new_payload = {
       'aud' => client.client_id,
       'iss' => base_config['token']['issuer'],
-      'sub' => uentry.username,
+      'sub' => user.username,
       'nbf' => now,
       'iat' => now,
       'exp' => now + base_config['id_token']['expiration']
-    }.merge(map_claims_to_userinfo(uentry.attributes, claims, client, scopes))
+    }.merge(map_claims_to_userinfo(user.attributes, claims, client, scopes))
     new_payload['nonce'] = nonce unless nonce.nil?
     signing_material = Server.load_skey('token')
     kid = JSON::JWK.new(signing_material['pk'])[:kid]

--- a/lib/token_helper.rb
+++ b/lib/token_helper.rb
@@ -15,7 +15,6 @@ end
 
 # A helper for building JWT access tokens and ID tokens
 class TokenHelper
-
   def self.build_access_token_stub(attrs, client, scopes, resources, claims)
     base_config = Config.base_config
     now = Time.new.to_i

--- a/lib/token_helper.rb
+++ b/lib/token_helper.rb
@@ -18,7 +18,7 @@ class TokenHelper
   def self.build_access_token_stub(attrs, client, scopes, resources, claims)
     base_config = Config.base_config
     now = Time.new.to_i
-    {
+    token = {
       'scope' => (scopes.join ' '),
       'aud' => resources,
       'iss' => base_config.dig('token', 'issuer'),
@@ -26,11 +26,12 @@ class TokenHelper
       'iat' => now,
       'jti' => Base64.urlsafe_encode64(rand(2**64).to_s),
       'exp' => now + base_config.dig('token', 'expiration'),
-      'client_id' => client.client_id,
-      'omejdn_reserved' => {
-        'userinfo_req_claims' => claims['userinfo']
-      }
-    }.merge(map_claims_to_userinfo(attrs, claims['access_token'], client, scopes))
+      'client_id' => client.client_id
+    }
+    reserved = {}
+    reserved['userinfo_req_claims'] = claims['userinfo'] unless (claims['userinfo'] || {}).empty?
+    token['omejdn_reserved'] = reserved unless reserved.empty?
+    token.merge(map_claims_to_userinfo(attrs, claims['access_token'], client, scopes))
   end
 
   # Builds a JWT access token for client including scopes and attributes

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -122,17 +122,4 @@ class User
     end
     false
   end
-
-  def remove_claim(claim)
-    attributes.each do |a|
-      attributes.delete a if a['key'] == claim
-    end
-  end
-
-  def add_scopeclaim(claim)
-    attributes.push({
-                      'key' => claim,
-                      'value' => true
-                    })
-  end
 end

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -108,18 +108,14 @@ class User
     user
   end
 
-  def claim?(claim)
-    parts = claim.split(':', 2)
-    searchkey = parts[0]
-    searchvalue = parts.length > 1 ? parts[1] : nil
-    attributes.each do |a|
-      key = a['key']
-      next unless key == searchkey
-
-      return a['value'] == searchvalue unless searchvalue.nil?
-
-      return true
+  def claim?(searchkey, searchvalue = nil)
+    attribute = attributes.select { |a| a['key'] == searchkey }.first
+    if attribute.nil?
+      false
+    elsif searchvalue.nil?
+      true
+    else
+      attribute['value'] == searchvalue
     end
-    false
   end
 end

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -9,7 +9,7 @@ require_relative './user_db'
 class User
   include BCrypt
 
-  attr_accessor :username, :password, :attributes, :extern, :backend
+  attr_accessor :username, :password, :attributes, :extern, :backend, :auth_time
 
   def self.verify_credential(user, pass)
     dbs = UserDbLoader.load_db

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -124,6 +124,10 @@ class RequestCache
 end
 
 before do
+  # We define global cache control headers here
+  # They may be overwritten where necessary
+  headers['Pragma'] = 'no-cache'
+  headers['Cache-Control'] = 'no-store'
   headers['Access-Control-Allow-Origin'] = Config.base_config['allow_origin']
   headers['Access-Control-Allow-Headers'] = 'content-type,if-modified-since, authorization'
   if request.env['REQUEST_METHOD'] == 'OPTIONS'
@@ -222,6 +226,11 @@ post '/token' do
   rescue OAuth2Error
     halt 400, OAuthHelper.error_response('invalid_scope', '')
   end
+end
+
+before '/.well-known*' do
+  headers['Cache-Control'] = "max-age=#{60 * 60 * 24}, must-revalidate"
+  headers.delete('Pragma')
 end
 
 get '/.well-known/openid-configuration' do

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -306,7 +306,8 @@ get '/authorize' do
       session[:tasks] << AuthorizationTask::ACCOUNT_SELECT
     end
   end
-  if params[:max_age] && (Time.new.to_i - session[:auth_time]) > params[:max_age]
+  if params[:max_age] && session[:user] &&
+     (Time.new.to_i - UserSession.get[session[:user]].auth_time) > params[:max_age]
     session[:tasks] << AuthorizationTask::LOGIN
   end
 
@@ -470,9 +471,9 @@ post '/login' do
   redirect to("#{my_path}/login?error=\"Credentials incorrect\"") unless User.verify_credential(user,
                                                                                                 params[:password])
   nonce = rand(2**512)
+  user.auth_time = Time.new.to_i
   UserSession.get[nonce] = user
   session[:user] = nonce
-  session[:auth_time] = Time.new.to_i
   next_task AuthorizationTask::LOGIN
 end
 
@@ -508,9 +509,9 @@ get '/oauth_cb' do
   return 'Internal Error' if user.username.nil?
 
   nonce = rand(2**512)
+  user.auth_time = Time.new.to_i
   UserSession.get[nonce] = user
   session[:user] = nonce
-  session[:auth_time] = Time.new.to_i
   next_task AuthorizationTask::LOGIN
 end
 

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -175,7 +175,7 @@ post '/token' do
     scopes = client.filter_scopes(params[:scope]&.split) || []
     resources = [Config.base_config.dig('token', 'audience')] if resources.empty?
     halt 400, OAuthHelper.error_response('invalid_target', '') unless client.resources_allowed? resources
-    req_claims = JSON.parse (params[:claims] || '{}')
+    req_claims = JSON.parse(params[:claims] || '{}')
 
   when 'authorization_code'
     code = params[:code]

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -161,10 +161,10 @@ post '/token' do
 
   if params[:grant_type] == 'client_credentials'
     if params[:client_assertion_type] != 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-      halt 400, OAuthHelper.error_response('invalid_request', 'Invalid client_assertion_type')
+      halt 400, OAuthHelper.error_response('unauthorized_grant', 'Invalid client_assertion_type')
     end
     jwt = params[:client_assertion]
-    halt 400, OAuthHelper.error_response('invalid_client', 'Assertion missing') if jwt.nil?
+    halt 400, OAuthHelper.error_response('invalid_grant', 'Assertion missing') if jwt.nil?
     client = Client.find_by_jwt jwt
     halt 400, OAuthHelper.error_response('invalid_client', 'Client unknown') if client.nil?
     scopes = client.filter_scopes(params[:scope]&.split) || []

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -215,9 +215,9 @@ post '/token' do
   begin
     user = cache&.dig(:user)
     nonce = cache&.dig(:nonce)
-    id_token = TokenHelper.build_id_token client, user, nonce, req_claims['id_token'], scopes if openid?(scopes)
+    id_token = TokenHelper.build_id_token client, user, scopes, req_claims, nonce if openid?(scopes)
     # https://tools.ietf.org/html/draft-bertocci-oauth-access-token-jwt-00#section-2.2
-    access_token = TokenHelper.build_access_token client, scopes, resources, user, req_claims['access_token']
+    access_token = TokenHelper.build_access_token client, user, scopes, req_claims, resources
     # Delete the authorization code as it is single use
     RequestCache.get.delete(code)
     OAuthHelper.token_response access_token, scopes, id_token
@@ -422,7 +422,7 @@ end
 
 get '/userinfo' do
   headers['Content-Type'] = 'application/json'
-  JSON.generate OAuthHelper.userinfo(@user, @token)
+  JSON.generate OAuthHelper.userinfo(@user, @token[0])
 end
 
 ########## LOGIN/LOGOUT ##################

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -191,7 +191,7 @@ post '/token' do
     end
     client = Client.find_by_id params[:client_id]
     halt 400, OAuthHelper.error_response('invalid_client', 'No client_id given') if client.nil?
-    if cache[:redirect_uri] && cache[:redirect_uri] == params[:redirect_uri]
+    if cache[:redirect_uri] && cache[:redirect_uri] != params[:redirect_uri]
       halt 400, OAuthHelper.error_response('invalid_request')
     end
     scopes = client.filter_scopes(params[:scope]&.split)

--- a/tests/config_testsetup.rb
+++ b/tests/config_testsetup.rb
@@ -55,7 +55,7 @@ class TestSetup
     [{
       'client_id' => 'testClient',
       'name' => 'omejdn admin ui',
-      'allowed_scopes' => ['omejdn:write'],
+      'allowed_scopes' => ['omejdn:write', 'openid', 'email'],
       'redirect_uri' => 'http://localhost:4200',
       'attributes' => []
     },

--- a/tests/test_admin_api.rb
+++ b/tests/test_admin_api.rb
@@ -17,8 +17,8 @@ class AdminApiTest < Test::Unit::TestCase
     TestSetup.setup
     
     client = Client.find_by_id 'testClient'
-    @token = TokenHelper.build_access_token client, ['omejdn:admin'], TestSetup.config['host']+"/api", nil, {}
-    @insufficient_token = TokenHelper.build_access_token client, ['omejdn:write'], "test", nil, {}
+    @token = TokenHelper.build_access_token client, nil, ['omejdn:admin'], {}, TestSetup.config['host']+"/api"
+    @insufficient_token = TokenHelper.build_access_token client, nil, ['omejdn:write'], {}, "test"
     @testCertificate = File.read './tests/test_resources/testClient.pem'
   end
 

--- a/tests/test_oauth2.rb
+++ b/tests/test_oauth2.rb
@@ -65,14 +65,14 @@ class OAuth2Test < Test::Unit::TestCase
 
   def extract_access_token(response)
     check_keys ["access_token","expires_in","token_type","scope"], response
-    assert_equal response["expires_in"], TestSetup.config.dig('token','expiration')
-    assert_equal response["token_type"], "bearer"
-    assert_equal response["scope"], "omejdn:write"
+    assert_equal TestSetup.config.dig('token','expiration'), response["expires_in"]
+    assert_equal "bearer", response["token_type"]
+    assert_equal "omejdn:write", response["scope"]
 
     jwt = decode_jwt response['access_token']
     check_keys ['typ','kid','alg'], jwt[1]
-    assert_equal jwt.dig(1,'typ'), 'at+jwt'
-    assert_equal jwt.dig(1,'alg'), TestSetup.config.dig('token','algorithm')
+    assert_equal 'at+jwt', jwt.dig(1,'typ')
+    assert_equal TestSetup.config.dig('token','algorithm'), jwt.dig(1,'alg')
 
     return jwt[0]
   end
@@ -82,15 +82,15 @@ class OAuth2Test < Test::Unit::TestCase
     at = extract_access_token response
 
     check_keys ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub'], at
-    assert_equal at['scope'], 'omejdn:write'
-    assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
-    assert_equal at['iss'], TestSetup.config.dig('token','issuer')
+    assert_equal 'omejdn:write', at['scope']
+    assert_equal [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api'], at['aud']
+    assert_equal TestSetup.config.dig('token','issuer'), at['iss']
     assert       at['nbf'] <= Time.new.to_i
-    assert_equal at['iat'], at['nbf']
-    assert_equal at['exp'], at['nbf']+response["expires_in"]
+    assert_equal at['nbf'], at['iat']
+    assert_equal at['nbf']+response["expires_in"], at['exp']
     assert       at['jti']
-    assert_equal at['client_id'], @client.client_id
-    assert_equal at['sub'], at['client_id']
+    assert_equal @client.client_id, at['client_id']
+    assert_equal at['client_id'], at['sub']
   end
 
   def test_client_credentials_with_resources
@@ -100,16 +100,15 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_client_credentials @client2, "ES256", @priv_key_ec256, @certificate_ec256, resources
     at = extract_access_token response
 
-    check_keys ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub'], at
-    assert_equal at['scope'], 'omejdn:write'
-    assert_equal at['aud'], ['http://example.org', TestSetup.config['host']+'/api']
-    assert_equal at['iss'], TestSetup.config.dig('token','issuer')
+    assert_equal 'omejdn:write', at['scope']
+    assert_equal ['http://example.org', TestSetup.config['host']+'/api'], at['aud']
+    assert_equal TestSetup.config.dig('token','issuer'), at['iss']
     assert       at['nbf'] <= Time.new.to_i
-    assert_equal at['iat'], at['nbf']
-    assert_equal at['exp'], at['nbf']+response["expires_in"]
+    assert_equal at['nbf'], at['iat']
+    assert_equal at['nbf']+response["expires_in"], at['exp']
     assert       at['jti']
-    assert_equal at['client_id'], @client2.client_id
-    assert_equal at['sub'], at['client_id']
+    assert_equal @client2.client_id, at['client_id']
+    assert_equal at['client_id'], at['sub']
   end
 
   def test_client_credentials_scope_rejection
@@ -118,15 +117,15 @@ class OAuth2Test < Test::Unit::TestCase
     at = extract_access_token response
 
     check_keys ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub'], at
-    assert_equal at['scope'], 'omejdn:write'
-    assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
-    assert_equal at['iss'], TestSetup.config.dig('token','issuer')
+    assert_equal 'omejdn:write', at['scope']
+    assert_equal [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api'], at['aud']
+    assert_equal TestSetup.config.dig('token','issuer'), at['iss']
     assert       at['nbf'] <= Time.new.to_i
-    assert_equal at['iat'], at['nbf']
-    assert_equal at['exp'], at['nbf']+response["expires_in"]
+    assert_equal at['nbf'], at['iat']
+    assert_equal at['nbf']+response["expires_in"], at['exp']
     assert       at['jti']
-    assert_equal at['client_id'], @client.client_id
-    assert_equal at['sub'], at['client_id']
+    assert_equal @client.client_id, at['client_id']
+    assert_equal at['client_id'], at['sub']
   end
 
   def test_client_credentials_dynamic_claims
@@ -145,16 +144,16 @@ class OAuth2Test < Test::Unit::TestCase
     at = extract_access_token response
 
     check_keys ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'dynattribute','omejdn_reserved'], at
-    assert_equal at['scope'], 'omejdn:write'
-    assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
-    assert_equal at['iss'], TestSetup.config.dig('token','issuer')
+    assert_equal 'omejdn:write', at['scope']
+    assert_equal [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api'], at['aud']
+    assert_equal TestSetup.config.dig('token','issuer'), at['iss']
     assert       at['nbf'] <= Time.new.to_i
-    assert_equal at['iat'], at['nbf']
-    assert_equal at['exp'], at['nbf']+response["expires_in"]
+    assert_equal at['nbf'], at['iat']
+    assert_equal at['nbf']+response["expires_in"], at['exp']
     assert       at['jti']
-    assert_equal at['client_id'], @client_dyn_claims.client_id
-    assert_equal at['sub'], at['client_id']
-    assert_equal at['dynattribute'], requested_claims.dig('*','dynattribute','value')
+    assert_equal @client_dyn_claims.client_id, at['client_id']
+    assert_equal at['client_id'], at['sub']
+    assert_equal requested_claims.dig('*','dynattribute','value'), at['dynattribute']
   end
 
   def test_algorithms
@@ -216,15 +215,15 @@ class OAuth2Test < Test::Unit::TestCase
     at = extract_access_token response
 
     check_keys ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn'], at
-    assert_equal at['scope'], 'omejdn:write'
-    assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
-    assert_equal at['iss'], TestSetup.config.dig('token','issuer')
+    assert_equal 'omejdn:write', at['scope']
+    assert_equal [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api'], at['aud']
+    assert_equal TestSetup.config.dig('token','issuer'), at['iss']
     assert       at['nbf'] <= Time.new.to_i
-    assert_equal at['iat'], at['nbf']
-    assert_equal at['exp'], at['nbf']+response["expires_in"]
+    assert_equal at['nbf'], at['iat']
+    assert_equal at['nbf']+response["expires_in"], at['exp']
     assert       at['jti']
-    assert_equal at['client_id'], @client.client_id
-    assert_equal at['sub'], TestSetup.users.dig(0,'username')
+    assert_equal @client.client_id, at['client_id']
+    assert_equal TestSetup.users.dig(0,'username'), at['sub']
     assert_equal 'write', at['omejdn']
   end
 
@@ -239,15 +238,15 @@ class OAuth2Test < Test::Unit::TestCase
     at = extract_access_token response
 
     check_keys ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn'], at
-    assert_equal at['scope'], 'omejdn:write'
-    assert_equal at['aud'], ['http://example.org', TestSetup.config['host']+'/api']
-    assert_equal at['iss'], TestSetup.config.dig('token','issuer')
+    assert_equal 'omejdn:write', at['scope']
+    assert_equal ['http://example.org', TestSetup.config['host']+'/api'], at['aud']
+    assert_equal TestSetup.config.dig('token','issuer'), at['iss']
     assert       at['nbf'] <= Time.new.to_i
-    assert_equal at['iat'], at['nbf']
-    assert_equal at['exp'], at['nbf']+response["expires_in"]
+    assert_equal at['nbf'], at['iat']
+    assert_equal at['nbf']+response["expires_in"], at['exp']
     assert       at['jti']
-    assert_equal at['client_id'], @client2.client_id
-    assert_equal at['sub'], TestSetup.users.dig(0,'username')
+    assert_equal @client2.client_id, at['client_id']
+    assert_equal TestSetup.users.dig(0,'username'), at['sub']
     assert_equal 'write', at['omejdn']
   end
 
@@ -268,16 +267,16 @@ class OAuth2Test < Test::Unit::TestCase
 
     p at
     check_keys ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn', 'dynattribute', 'omejdn_reserved'], at
-    assert_equal at['scope'], 'omejdn:write'
-    assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
-    assert_equal at['iss'], TestSetup.config.dig('token','issuer')
+    assert_equal 'omejdn:write', at['scope']
+    assert_equal [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api'], at['aud']
+    assert_equal TestSetup.config.dig('token','issuer'), at['iss']
     assert       at['nbf'] <= Time.new.to_i
-    assert_equal at['iat'], at['nbf']
-    assert_equal at['exp'], at['nbf']+response["expires_in"]
+    assert_equal at['nbf'], at['iat']
+    assert_equal at['nbf']+response["expires_in"], at['exp']
     assert       at['jti']
-    assert_equal at['client_id'], @client.client_id
-    assert_equal at['sub'], TestSetup.users.dig(2,'username')
+    assert_equal @client.client_id, at['client_id']
+    assert_equal TestSetup.users.dig(2,'username'), at['sub']
     assert_equal 'write', at['omejdn']
-    assert_equal at['dynattribute'], requested_claims.dig('*','dynattribute','value')
+    assert_equal requested_claims.dig('*','dynattribute','value'), at['dynattribute']
   end
 end

--- a/tests/test_oauth2.rb
+++ b/tests/test_oauth2.rb
@@ -82,7 +82,7 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_client_credentials @client, "ES256", @priv_key_ec256, @certificate_ec256
     at = extract_access_token response
 
-    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub']
+    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub','omejdn_reserved']
     assert_equal at['scope'], 'omejdn:write'
     assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
     assert_equal at['iss'], TestSetup.config.dig('token','issuer')
@@ -101,7 +101,7 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_client_credentials @client2, "ES256", @priv_key_ec256, @certificate_ec256, resources
     at = extract_access_token response
 
-    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub']
+    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub','omejdn_reserved']
     assert_equal at['scope'], 'omejdn:write'
     assert_equal at['aud'], ['http://example.org', TestSetup.config['host']+'/api']
     assert_equal at['iss'], TestSetup.config.dig('token','issuer')
@@ -118,7 +118,7 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_client_credentials @client, "ES256", @priv_key_ec256, @certificate_ec256, additional_scopes
     at = extract_access_token response
 
-    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub']
+    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub','omejdn_reserved']
     assert_equal at['scope'], 'omejdn:write'
     assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
     assert_equal at['iss'], TestSetup.config.dig('token','issuer')
@@ -145,7 +145,7 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_client_credentials @client_dyn_claims, "ES256", @priv_key_ec256, @certificate_ec256, query_additions
     at = extract_access_token response
 
-    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'dynattribute']
+    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'dynattribute','omejdn_reserved']
     assert_equal at['scope'], 'omejdn:write'
     assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
     assert_equal at['iss'], TestSetup.config.dig('token','issuer')
@@ -215,7 +215,7 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_authorization TestSetup.users[0], @client
     at = extract_access_token response
 
-    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn']
+    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn','omejdn_reserved']
     assert_equal at['scope'], 'omejdn:write'
     assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
     assert_equal at['iss'], TestSetup.config.dig('token','issuer')
@@ -238,7 +238,7 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_authorization TestSetup.users[0], @client2, resources
     at = extract_access_token response
 
-    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn']
+    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn','omejdn_reserved']
     assert_equal at['scope'], 'omejdn:write'
     assert_equal at['aud'], ['http://example.org', TestSetup.config['host']+'/api']
     assert_equal at['iss'], TestSetup.config.dig('token','issuer')
@@ -266,7 +266,8 @@ class OAuth2Test < Test::Unit::TestCase
     response = request_authorization TestSetup.users[2], @client, query_additions
     at = extract_access_token response
 
-    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn', 'dynattribute']
+    p at
+    check_keys at, ['scope','aud','iss','nbf','iat','jti','exp','client_id','sub', 'omejdn', 'dynattribute','omejdn_reserved']
     assert_equal at['scope'], 'omejdn:write'
     assert_equal at['aud'], [TestSetup.config.dig('token','audience'), TestSetup.config['host']+'/api']
     assert_equal at['iss'], TestSetup.config.dig('token','issuer')

--- a/tests/test_oauth2.rb
+++ b/tests/test_oauth2.rb
@@ -204,7 +204,8 @@ class OAuth2Test < Test::Unit::TestCase
     query = 'grant_type=authorization_code'+
     '&code='+code+
     '&client_id='+client.client_id+
-    '&scope=omejdn:write'+query_additions
+    '&scope=omejdn:write'+query_additions+
+    '&redirect_uri='+client.redirect_uri
     post ('/token?'+query), {}, {}
     good_so_far &= last_response.ok?
     assert good_so_far == should_work

--- a/tests/test_selfservice_api.rb
+++ b/tests/test_selfservice_api.rb
@@ -17,9 +17,9 @@ class SelfServiceApiTest < Test::Unit::TestCase
     TestSetup.setup
     user = User.find_by_id 'testUser'
     client = Client.find_by_id 'testClient'
-    @write_token = TokenHelper.build_access_token client, ['omejdn:write'], TestSetup.config['host']+"/api", user, {}
-    @read_token = TokenHelper.build_access_token client, ['omejdn:read'], TestSetup.config['host']+"/api", user, {}
-    @useless_token = TokenHelper.build_access_token client, [], TestSetup.config['host']+"/api", user, {}
+    @write_token   = TokenHelper.build_access_token client, user, ['omejdn:write'], {}, TestSetup.config['host']+"/api"
+    @read_token    = TokenHelper.build_access_token client, user, ['omejdn:read'],  {}, TestSetup.config['host']+"/api"
+    @useless_token = TokenHelper.build_access_token client, user, [],               {}, TestSetup.config['host']+"/api"
   end
 
   def teardown

--- a/views/authorization_page.haml
+++ b/views/authorization_page.haml
@@ -7,7 +7,7 @@
   %span Currently logged in as 
   %b #{locals[:user].username}
   %a{:href => "#{locals[:host]}/logout", :class => "button"} Change...
-%form{:action => "#{locals[:host]}/authorize", :method => "post"}
+%form{:action => "#{locals[:host]}/consent", :method => "post"}
   %fieldset
     %br
     %h3 Requested scopes:


### PR DESCRIPTION
This PR adresses issue #22 by making the authorization flow adjustable.

The user's session contains a list of tasks to do before an `authorization_code` is issued.
These *may* include:

* Logging in
* Granting the client access to the requested scopes

Both Omejdn and the client (via the `prompt` and `max_age` request parameters) may require certain tasks to be fulfilled.

Other changes:
* The consent screen was moved to `/consent`.
* Replaced repeated uses of the `[]` operator with `dig()`, as they were a reoccuring source of unexpected `nil` errors.