### PR TITLE
Updated Test token script

### DIFF
--- a/scripts/create_test_token.rb
+++ b/scripts/create_test_token.rb
@@ -1,47 +1,41 @@
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'openssl'
 require 'jwt'
 require 'json'
 
-##
-# NOTE:
-# The client_id in config/clients.yml must match the 'iss' and 'sub' claim
-# of the JWT you generate.
-# Do not forget to configure the 'certfile' of your client so that
-# omejdn can find you public key which corrsponds to the private key you
-# use to sign this JWT.
-#
-# The 'aud' claim MUST correspond to the HOST environment parameter
-# or the 'host' value in the config/omejdn.yml.
-# Alternatively, if omejdn is started with the OMEJDN_JWT_AUD_OVERRIDE
-# environment variable you must use that value instead.
-#
-
-CLIENTID = 'testClient'
-
-def load_key
-  if File.exist? "keys/#{CLIENTID}.key"
-    filename = "keys/#{CLIENTID}.key"
-    rsa_key = OpenSSL::PKey::RSA.new File.read(filename)
-  else
-    rsa_key = OpenSSL::PKey::RSA.new 2048
-    pfile = File.new "keys/#{CLIENTID}.key", File::CREAT | File::TRUNC | File::RDWR
-    pfile.write(rsa_key.to_pem)
-    pfile.close
-  end
-  rsa_key
+def error(msg)
+  print "#{msg}\n"
+  exit
 end
 
-# Only for debugging!
-client_rsa_key = load_key
+if ARGV.length < 2 || ARGV.length > 3
+  error "Usage: create_test_token.rb client_id keyfile (AUD)\n" \
+        "\n" \
+        "NOTE: The client_id must be specified in `config/clients.yml`.\n" \
+        "A certificate for the client must be registered. If in doubt,\n" \
+        "use the `import_certfile` option in `config/clients.yml` to\n" \
+        "import it. The AUD value must correspond to the value set by\n" \
+        "Omejdn. If you overwrote it, you must specify the correct\n" \
+        'value here. This script only supports RSA keys.'
+end
+
+client_id = ARGV[0]
+keyfile = ARGV[1]
+aud = ENV['HOST'] || 'http://localhost:4567'
+aud = ARGV[2] if ARGV.length >= 3
+
+error 'ERROR: File not existent.' unless File.exist? keyfile
+key = OpenSSL::PKey::RSA.new File.read(keyfile)
+
 payload = {
-  'iss' => CLIENTID,
-  'sub' => CLIENTID,
+  'iss' => client_id,
+  'sub' => client_id,
   'exp' => Time.new.to_i + 3600,
   'nbf' => Time.new.to_i,
   'iat' => Time.new.to_i,
-  'aud' => 'http://localhost:4567' # The omejdn host or OMEJDN_JWT_AUD_OVERRIDE value
+  'aud' => aud
 }
-token = JWT.encode payload, client_rsa_key, 'RS256'
+token = JWT.encode payload, key, 'RS256'
 puts token


### PR DESCRIPTION
The script `create_test_token.rb` has been reworked to accept command line parameters like so:

```
$ create_test_token.rb client_id keyfile (AUD)
```

AUD needs to be specified only if
* The `HOST` environment variable is different from the server
* `OMEJDN_JWT_AUD_OVERWRITE` was used