### PR TITLE
Jar par

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,6 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Max: 50
 Metrics/CyclomaticComplexity:
-  Max: 15
+  Max: 20
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 20

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -176,13 +176,13 @@ class OAuthHelper
     metadata['jwks_uri'] = "#{host}/.well-known/jwks.json"
     # metadata["registration_endpoint"] = "#{host}/FIXME"
     metadata['scopes_supported'] = OAuthHelper.supported_scopes
-    metadata['response_types_supported'] = ['code']
+    metadata['response_types_supported'] = %w[code fragment form_post]
     metadata['response_modes_supported'] = ['query'] # FIXME: we only do query atm no fragment
     metadata['grant_types_supported'] = ['authorization_code']
     metadata['token_endpoint_auth_methods_supported'] = %w[none private_key_jwt]
     metadata['token_endpoint_auth_signing_alg_values_supported'] = %w[RS256 RS512 ES256 ES512]
     metadata['service_documentation'] = 'https://github.com/Fraunhofer-AISEC/omejdn-server/wiki'
-    # metadata['ui_locales_supported'] =
+    metadata['ui_locales_supported'] = []
     # metadata['op_policy_uri'] =
     # metadata['op_tos_uri'] =
     # metadata['revocation_endpoint'] =
@@ -197,8 +197,8 @@ class OAuthHelper
     # metadata['device_authorization_endpoint'] =
 
     # RFC 8705
-    # metadata['tls_client_certificate_bound_access_tokens'] =
-    # metadata['mtls_endpoint_aliases'] =
+    metadata['tls_client_certificate_bound_access_tokens'] = false
+    metadata['mtls_endpoint_aliases'] = {}
 
     # RFC 9101
     metadata['require_signed_request_object'] = true
@@ -228,7 +228,7 @@ class OAuthHelper
     metadata['display_values_supported'] = ['page'] # TODO: Different UIs
     metadata['claim_types_supported'] = ['normal']
     metadata['claims_supported'] = [] # TODO: What to disclose here?
-    # metadata['claims_locales_supported'] =
+    metadata['claims_locales_supported'] = []
     metadata['claims_parameter_supported'] = true
     metadata['request_parameter_supported'] = true
     metadata['request_uri_parameter_supported'] = true

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -31,7 +31,7 @@ class OAuthHelper
     client = nil
     if params[:client_assertion_type] # RFC 7521, Section 4.2
       if params[:client_assertion_type] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-        client = Client.find_by_jwt params[:client_assertion]
+        _, client = Client.decode_jwt params[:client_assertion]
       end
       raise OAuthError.new 'invalid_client', 'Client unknown' if client.nil?
 

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -10,16 +10,93 @@ require 'digest'
 
 # The OAuth Exception class
 class OAuthError < RuntimeError
-  attr_reader :reason
+  attr_reader :type, :description
 
-  def initialize(reason)
-    super
-    @reason = reason
+  def initialize(type, description = '')
+    super('')
+    @type = type
+    @description = description
+  end
+
+  def to_s
+    { 'error' => @type, 'error_description' => @description }.to_json
   end
 end
 
 # Helper functions for OAuth related tasks
 class OAuthHelper
+  # Identifies a client from the request parameters and optionally enforces authentication
+  def self.identify_client(params, authenticate: true)
+    client = nil
+    if params[:client_assertion_type] # RFC 7521, Section 4.2
+      if params[:client_assertion_type] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+        client = Client.find_by_jwt params[:client_assertion]
+      end
+      raise OAuthError.new 'invalid_client', 'Client unknown' if client.nil?
+
+      return client
+    end
+
+    raise OAuthError.new 'invalid_client', 'Client unknown' if authenticate
+
+    client = Client.find_by_id params[:client_id]
+    raise OAuthError.new 'invalid_client', 'Client unknown' if client.nil?
+
+    client
+  end
+
+  # Retrieves the request parameters from the URL parameters, for authorization flows
+  def self.prepare_params(url_params)
+    # We deviate from the OIDC spec in favor of RFC 9101
+    # For example, we do not require specifying the scope outside the request parameter,
+    # if it is provided within said parameter.
+    # On the other hand, we require https!
+    jwt = nil
+    params = nil
+    if url_params.key? :request_uri
+      throw OAuthError.new 'invalid_request' if url_params.key? :request
+
+      if url_params[:request_uri].start_with? 'urn:ietf:params:oauth:request_uri:'
+        # Retrieve token from Pushed Authorization Request Cache
+        params = PARCache.get[url_params[:request_uri]]
+      elsif url_params[:request_uri].start_with? 'https://'
+        # Retrieve remote token
+        begin
+          uri = URI(url_params[:request_uri])
+          Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+            res = http.request Net::HTTP::Get.new(uri)
+            jwt = res.body
+          end
+        rescue StandardError
+          jwt = nil
+        end
+      elsif jwt.nil?
+        throw OAuthError.new 'invalid_request_uri'
+      end
+    elsif url_params.key? :request
+      jwt = url_params[:request]
+      throw OAuthError.new 'invalid_request_object' if jwt.nil?
+    end
+
+    return url_params if jwt.nil? && params.nil?
+
+    if jwt
+      jwt_untrusted = JWT.decode jwt, nil, false
+      throw OAuthError.new 'invalid_client' if jwt_untrusted.dig(0, 'client_id') != url_params[:client_id]
+
+      client = Client.find_by_id url_params[:client_id]
+      throw OAuthError.new 'invalid_client' if client.nil?
+
+      aud = Config.base_config['accept_audience']
+      params = (JWT.decode jwt, client.certificate&.public_key, true,
+                           { nbf_leeway: 30, aud: aud, verify_aud: true, algorithm: jwt_untrusted.dig(1, 'alg') })[0]
+    end
+
+    url_params.delete(:request_uri)
+    url_params.delete(:request)
+    url_params.merge! params
+  end
+
   def self.token_response(access_token, scopes, id_token)
     response = {}
     response['access_token'] = access_token
@@ -43,7 +120,6 @@ class OAuthHelper
 
   def self.error_response(error, desc = '')
     response = { 'error' => error, 'error_description' => desc }
-    p response
     JSON.generate response
   end
 
@@ -52,12 +128,13 @@ class OAuthHelper
   end
 
   def self.validate_pkce(code_challenge, code_verifier, method)
-    raise unless method == 'S256'
+    raise OAuthError.new 'invalid_request', "Unsupported verifier method: #{method}" unless method == 'S256'
+    raise OAuthError.new 'invalid_request', 'Code verifier missing' if code_verifier.nil?
 
     digest = Digest::SHA256.new
     digest << code_verifier
     expected_challenge = digest.base64digest.gsub('+', '-').gsub('/', '_').gsub('=', '')
-    expected_challenge == code_challenge
+    raise OAuthError.new 'invalid_request', 'Code verifier mismatch' unless expected_challenge == code_challenge
   end
 
   def self.generate_jwks

--- a/lib/token_helper.rb
+++ b/lib/token_helper.rb
@@ -10,9 +10,6 @@ require 'openssl'
 # Need this constant to encode subject the right way.
 ASN1_STRFLGS_ESC_MSB = 4
 
-class OAuth2Error < RuntimeError
-end
-
 # A helper for building JWT access tokens and ID tokens
 class TokenHelper
   def self.build_access_token_stub(attrs, client, scopes, resources, claims)

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -409,8 +409,18 @@ def issue_code
   code = OAuthHelper.new_authz_code
   RequestCache.get[code] = cache
   redirect_uri = session.delete(:redirect_uri_verified)
-  resp = "?code=#{code}&state=#{url_params[:state]}"
-  redirect to(redirect_uri + resp)
+  response_params = {
+    code: code,
+    state: url_params[:state]
+  }
+  case url_params[:response_mode]
+  when 'form_post'
+    halt 200, (haml :submitted, locals: response_params.merge({ redirect_uri: redirect_uri }))
+  when 'fragment'
+    redirect to("#{redirect_uri}##{URI.encode_www_form response_params}")
+  else # 'query' and unsupported types
+    redirect to("#{redirect_uri}?#{URI.encode_www_form response_params}")
+  end
 end
 
 ########## USERINFO ##################

--- a/omejdn.rb
+++ b/omejdn.rb
@@ -819,19 +819,17 @@ end
 ########## WELL-KNOWN ENDPOINTS ##################
 
 before '/.well-known*' do
+  headers['Content-Type'] = 'application/json'
   headers['Cache-Control'] = "max-age=#{60 * 60 * 24}, must-revalidate"
   headers.delete('Pragma')
 end
 
 get '/.well-known/jwks.json' do
-  headers['Content-Type'] = 'application/json'
   OAuthHelper.generate_jwks.to_json
 end
 
-get '/.well-known/openid-configuration' do
-  headers['Content-Type'] = 'application/json'
-  p "Host #{Config.base_config['host']},#{my_path}"
-  JSON.generate OAuthHelper.openid_configuration(Config.base_config['host'], my_path)
+get '/.well-known/(oauth-authorization-server|openid-configuration)' do
+  JSON.generate OAuthHelper.configuration_metadata(Config.base_config['host'], my_path)
 end
 
 get '/.well-known/webfinger' do

--- a/tests/test_oauth_helper.rb
+++ b/tests/test_oauth_helper.rb
@@ -6,7 +6,7 @@ require 'test/unit'
 # Basic OAuth Tester
 class TestOAuthHelper < Test::Unit::TestCase
   def test_pkce
-    assert(OAuthHelper.validate_pkce('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
-                                     'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', 'S256'))
+    OAuthHelper.validate_pkce('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+                                     'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', 'S256')
   end
 end

--- a/views/submitted.haml
+++ b/views/submitted.haml
@@ -1,0 +1,9 @@
+%link{:type => "text/css", :rel => "stylesheet", :href => "css/main.css"}
+%body{:onload => 'javascript:document.forms[0].submit()'}
+  <center>
+  %div
+    %form{:action => "#{locals[:redirect_uri]}", :method => "post"}
+      %fieldset
+        %input{:type => "hidden", :name => "state", :value => "#{locals[:state]}"}
+        %input{:type => "hidden", :name => "code",  :value => "#{locals[:code]}"}
+  </center>


### PR DESCRIPTION
This PR adds basic support for the following specifications:

* [RFC 8414](https://datatracker.ietf.org/doc/rfc8414/) OAuth 2.0 Authorization Server Metadata
* [RFC 9101](https://datatracker.ietf.org/doc/rfc9101/) The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)
* [RFC 9126](https://datatracker.ietf.org/doc/rfc9126/) OAuth 2.0 Pushed Authorization Requests
* [OIDC](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html) OAuth 2.0 Form Post Response Mode

It also fixes some problems regarding error handling during the authorization flow.