### PR TITLE
Added support for draft-ietf-oauth-iss-auth-resp

### DIFF
--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -229,6 +229,9 @@ class OAuthHelper
     # metadata['introspection_encryption_alg_values_supported'] =
     # metadata['introspection_encryption_enc_values_supported'] =
 
+    # RFC-ietf-oauth-iss-auth-resp-04
+    metadata['authorization_response_iss_parameter_supported'] = true
+
     # OpenID Connect Discovery 1.0
     metadata.merge!(configuration_metadata_oidc_discovery(base_config, host, path))
 

--- a/tests/test_oauth2.rb
+++ b/tests/test_oauth2.rb
@@ -195,6 +195,7 @@ class OAuth2Test < Test::Unit::TestCase
     assert code=header_hash[client.redirect_uri+'?code'].first
     # p code
     assert_equal 'testState', header_hash['state'].first
+    assert_equal TestSetup.config['token']['issuer'], header_hash['iss'].first
 
     # Get /token
     query = 'grant_type=authorization_code'+

--- a/views/submitted.haml
+++ b/views/submitted.haml
@@ -6,4 +6,5 @@
       %fieldset
         %input{:type => "hidden", :name => "state", :value => "#{locals[:state]}"}
         %input{:type => "hidden", :name => "code",  :value => "#{locals[:code]}"}
+        %input{:type => "hidden", :name => "iss",  :value => "#{locals[:iss]}"}
   </center>


### PR DESCRIPTION
This will become an RFC soon.

TL;DR: We need to send our issuer identifier with all authorization-responses to prevent mix-up-attacks for clients with multiple registered authorization servers, and advertise this capability in the server metadata.